### PR TITLE
fix: add setuptools to atomicwrites build dependencies (CI #24274955512)

### DIFF
--- a/mods/fix-atomicwrites-overlay.nix
+++ b/mods/fix-atomicwrites-overlay.nix
@@ -1,0 +1,12 @@
+# Fix for atomicwrites-1.4.1 missing setuptools build dependency
+# Issue: After nix flake update, atomicwrites now requires explicit setuptools
+# in build-system.requires but nixpkgs definition hasn't been updated
+# Error: 'No module named setuptools' during wheel build
+# Affected: hermes-agent-env → hermes-agent → system-path → nixos-system-eldo
+
+final: prev: {
+  # Override atomicwrites to add setuptools to nativeBuildInputs
+  atomicwrites = prev.atomicwrites.overridePythonAttrs (oldAttrs: {
+    nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++ [ prev.python3.pkgs.setuptools ];
+  });
+}

--- a/overlays.nix
+++ b/overlays.nix
@@ -2,6 +2,9 @@
   (import ./mods/hax.nix)
   (import ./mods/mods.nix)
 
+  # CI Fix: atomicwrites missing setuptools build dependency (run #24274955512)
+  (import ./mods/fix-atomicwrites-overlay.nix)
+
   # Jade's Pogs
   (import ./mods/pog/colmena.nix)
   (import ./mods/pog/k8s.nix)


### PR DESCRIPTION
## What Failed

The NixOS configuration build for **eldo** (ubuntu-24.04) failed during CI run #24274955512 with a Python package build error.

**Failed derivation:** `/nix/store/4knqdsc9z8sg80swz7cva3bpkxzfy317-atomicwrites-1.4.1.drv`

## Root Cause

The Python package `atomicwrites-1.4.1` in nixpkgs is missing the `setuptools` build dependency after a recent `nix flake update`. The package now requires explicit `setuptools` in `build-system.requires`, but the nixpkgs definition has not been updated to include it.

**Error encountered:** `No module named 'setuptools' during wheel build`

**Failure cascade:**
1. atomicwrites-1.4.1.drv (failed)
2. hermes-agent-env.drv (blocked)
3. hermes-agent-0.8.0.drv (blocked)
4. system-path.drv (blocked)
5. nixos-system-eldo-26.05.20260409.4c1018d.drv (blocked)

## What This Fix Does

Adds a Nix overlay (`mods/fix-atomicwrites-overlay.nix`) that injects `setuptools` into `atomicwrites.nativeBuildInputs`. This resolves the immediate build failure while waiting for an upstream fix in nixpkgs.

**Files changed:**
- `mods/fix-atomicwrites-overlay.nix` (new overlay file)
- `overlays.nix` (include the new overlay)

**Impact:** Only affects the eldo (NixOS) build. The airbook (macOS) build was unaffected.

## Reference

Failed run: https://github.com/fisherrjd/nix/actions/runs/24274955512

---
*Auto-generated fix via Hermes CI agent*
