### PR TITLE
fix: correct atomicwrites overlay to use python3.packageOverrides

### DIFF
--- a/mods/fix-atomicwrites-overlay.nix
+++ b/mods/fix-atomicwrites-overlay.nix
@@ -3,10 +3,15 @@
 # in build-system.requires but nixpkgs definition hasn't been updated
 # Error: 'No module named setuptools' during wheel build
 # Affected: hermes-agent-env → hermes-agent → system-path → nixos-system-eldo
+#
+# Fix: Override python3 package set to inject setuptools into atomicwrites
 
 final: prev: {
-  # Override atomicwrites to add setuptools to nativeBuildInputs
-  atomicwrites = prev.atomicwrites.overridePythonAttrs (oldAttrs: {
-    nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++ [ prev.python3.pkgs.setuptools ];
-  });
+  python3 = prev.python3.override {
+    packageOverrides = pyfinal: pyprev: {
+      atomicwrites = pyprev.atomicwrites.overridePythonAttrs (oldAttrs: {
+        nativeBuildInputs = (oldAttrs.nativeBuildInputs or [ ]) ++ [ pyfinal.setuptools ];
+      });
+    };
+  };
 }


### PR DESCRIPTION
## What Failed

CI run [24286426986](https://github.com/fisherrjd/nix/actions/runs/24286426986) failed building the NixOS configuration for eldo.

Build error chain:
-  failed to build with 
- This broke  → 🤖 AI Agent with Tool Calling
==================================================
🤖 AI Agent initialized with model: 
🔑 Using API key: fw_J976P...qJs4
🛠️  Final tool selection (28 tools): browser_back, browser_click, browser_console, browser_get_images, browser_navigate, browser_press, browser_scroll, browser_snapshot, browser_type, browser_vision, clarify, cronjob, delegate_task, execute_code, memory, patch, process, read_file, search_files, session_search, skill_manage, skill_view, skills_list, terminal, text_to_speech, todo, vision_analyze, write_file
🛠️  Loaded 28 tools: browser_back, browser_click, browser_console, browser_get_images, browser_navigate, browser_press, browser_scroll, browser_snapshot, browser_type, browser_vision, clarify, cronjob, delegate_task, execute_code, memory, patch, process, read_file, search_files, session_search, skill_manage, skill_view, skills_list, terminal, text_to_speech, todo, vision_analyze, write_file
⚠️  Some tools may not work due to missing requirements: ['homeassistant', 'image_gen', 'messaging', 'moa', 'rl', 'web']
📊 Context limit: 131,072 tokens (compress at 50% = 65,536)

📝 User Query: Tell me about the latest developments in Python 3.13 and what new features developers should know about. Please search for current information and try it out.

==================================================
💬 Starting conversation: 'Tell me about the latest developments in Python 3.13 and wha...'

🔄 Making API call #1/10...
   📊 Request size: 2 messages, ~5,950 tokens (~23,802 chars)
   🔧 Available tools: 28
⚠️  API call failed (attempt 1/3): BadRequestError [HTTP 400]
   🔌 Provider:   Model: 
   🌐 Endpoint: 
   📝 Error: HTTP 400: Model is required but not provided
   📋 Details: {'message': 'Model is required but not provided', 'param': 'model', 'code': 'BAD_REQUEST', 'type': 'error'}
   ⏱️  Elapsed: 0.76s  Context: 2 msgs, ~5,950 tokens
⏳ Retrying in 2.9534603049771606s (attempt 1/3)...
⚠️  API call failed (attempt 2/3): BadRequestError [HTTP 400]
   🔌 Provider:   Model: 
   🌐 Endpoint: 
   📝 Error: HTTP 400: Model is required but not provided
   📋 Details: {'message': 'Model is required but not provided', 'param': 'model', 'code': 'BAD_REQUEST', 'type': 'error'}
   ⏱️  Elapsed: 4.28s  Context: 2 msgs, ~5,950 tokens
⏳ Retrying in 4.083765658631604s (attempt 2/3)...
⚠️  API call failed (attempt 3/3): BadRequestError [HTTP 400]
   🔌 Provider:   Model: 
   🌐 Endpoint: 
   📝 Error: HTTP 400: Model is required but not provided
   📋 Details: {'message': 'Model is required but not provided', 'param': 'model', 'code': 'BAD_REQUEST', 'type': 'error'}
   ⏱️  Elapsed: 8.96s  Context: 2 msgs, ~5,950 tokens
⚠️ Max retries (3) exhausted — trying fallback...
❌ API failed after 3 retries — HTTP 400: Model is required but not provided
   💀 Final error: HTTP 400: Model is required but not provided
🧾 Request debug dump written to: /home/jade/.hermes/sessions/request_dump_20260411_101922_181f44_20260411_101931_754661.json

==================================================
📋 CONVERSATION SUMMARY
==================================================
✅ Completed: False
📞 API Calls: 1
💬 Messages: 1

🎯 FINAL RESPONSE:
------------------------------
API call failed after 3 retries: HTTP 400: Model is required but not provided

👋 Agent execution completed! →  → 

## Root Cause

The existing overlay in  attempted to override  at the top level of nixpkgs:



However,  is a Python package nested within . The override was not being applied correctly because it was targeting the wrong attribute path.

## What This Fix Does

Updates the overlay to properly override  within the Python package set using :



This is the standard pattern for overriding Python packages in nixpkgs overlays.

## Verification

- [x] Overlay syntax validated with 
- [x] Commit follows conventional commit format
- [x] Branch naming matches CI failure run ID

---

Failed run: https://github.com/fisherrjd/nix/actions/runs/24286426986