### PR TITLE
fix(ci): resolve apr-util build failure on macOS 15

### DIFF
--- a/home.nix
+++ b/home.nix
@@ -106,7 +106,7 @@ in
           nix-info
           nix-output-monitor
           nix-prefetch-github
-          nix-prefetch-scripts
+          (lib.optionals isLinux [ nix-prefetch-scripts ])
           nix-tree
           nix-update
           nixpkgs-fmt

--- a/modules/home_configurations/git.nix
+++ b/modules/home_configurations/git.nix
@@ -30,7 +30,9 @@ in
     in
     {
       enable = true;
-      package = pkgs.gitFull;
+      # Use gitFull on Linux (with SVN support), plain git on Darwin
+      # Fixes: apr-util-1.6.3 build failure on macOS 15 (SDK compatibility issue)
+      package = if isDarwin then pkgs.git else pkgs.gitFull;
       signing.format = "openpgp";
       settings = {
         user = {


### PR DESCRIPTION
## What Failed

CI build failed on **airbook (macOS 15)** in run [#24919028668](https://github.com/fisherrjd/nix/actions/runs/24919028668).

The build failed with:

	nix (airbook on macos-15)  fail if build failed  Process completed with exit code 1

## Root Cause

Upstream nixpkgs package **apr-util-1.6.3** is currently broken on macOS 15 (SDK compatibility issue). 

The compilation error in apr-util:

	dbm/sdbm/sdbm_pair.c:132:14: error: unknown type name 'key'
	fatal error: too many errors emitted, stopping now [-ferror-limit-]

This caused a cascade of build failures:
- `git-with-svn-2.53.0` (depends on subversion → apr-util)
- `nix-prefetch-svn` (depends on subversion → apr-util)
- `nix-prefetch-scripts` (meta-package including svn prefetcher)
- `home-manager-path` and all dependent derivations

## What This Fix Does

1. **Conditionally use plain git on Darwin**: Changed `pkgs.gitFull` to `pkgs.git` on Darwin systems, removing SVN support from the git package.

2. **Disable nix-prefetch-scripts on Darwin**: Made `nix-prefetch-scripts` Linux-only since it includes `nix-prefetch-svn` which requires the broken apr-util.

Both packages remain fully available on Linux where apr-util builds correctly.

## Files Changed

- `modules/home_configurations/git.nix`: Use `pkgs.git` instead of `pkgs.gitFull` on Darwin
- `home.nix`: Make `nix-prefetch-scripts` conditional on `isLinux"

---

**Note**: This is a temporary workaround for an upstream nixpkgs issue. Once apr-util is fixed in nixpkgs, these changes can be reverted if SVN support is desired on Darwin.