### PR TITLE
fix: remove broken pkgs.hax reference causing CI failure

### DIFF
--- a/modules/home_configurations/git.nix
+++ b/modules/home_configurations/git.nix
@@ -1,7 +1,5 @@
 { pkgs, username, ... }:
 let
-  inherit (pkgs.hax) isDarwin isLinux isM1;
-
   firstName = "jade";
   lastName = "fisher";
 


### PR DESCRIPTION
## Summary

Fixes Nix evaluation failure caused by a removed upstream attribute.

## What Failed

CI run failed on both macOS (airbook) and Ubuntu (eldo) with:

```
error: attribute 'hax' missing
at /home/runner/work/nix/nix/modules/home_configurations/git.nix:3:12:
     2| let
     3|   inherit (pkgs.hax) isDarwin isLinux isM1;
              |            ^
     4|
Did you mean one of ham, has, haxe, hex or hpx?
```

## Root Cause

The `pkgs.hax` attribute was removed from jacobi's nixpkgs overlay (upstream dependency). This appears to be a cleanup/migration in the nix ecosystem being used.

## What This Fix Does

Removes the broken `inherit (pkgs.hax) isDarwin isLinux isM1;` line from `modules/home_configurations/git.nix`.

The variables (`isDarwin`, `isLinux`, `isM1`) were not actually referenced anywhere in the file, so this change is purely a removal of dead/broken code with no behavioral impact.

## Verification

- [x] Nix file syntax verified
- [x] No consumers of the removed variables in the codebase

## Failed Run

https://github.com/fisherrjd/nix/actions/runs/24919255234