### PR TITLE
Db fix (#435)

### DIFF
--- a/.github/workflows/check-postgres-pin.yml
+++ b/.github/workflows/check-postgres-pin.yml
@@ -1,0 +1,51 @@
+name: check postgres timescaledb pin
+# Guards against the ge-data TimescaleDB version-mismatch incident:
+# hosts/eldo/configuration.nix pins postgres+timescaledb to the dedicated
+# `nixpkgs-postgresql` flake input. ge-data's extension is recorded in
+# pg_extension at 2.27.2, so the pinned input MUST keep shipping 2.27.2 or
+# every ge-data connection breaks with
+#   ERROR: could not access file "$libdir/timescaledb-<v>": No such file...
+#
+# This job FAILS only if the pinned input drifts off 2.27.2 (the real hazard —
+# e.g. someone bumps the nixpkgs-postgresql rev). The rolling `nixpkgs` input
+# moving away from 2.27.2 is EXPECTED and benign (eldo uses the pin, not
+# rolling), so that is reported as a non-blocking warning.
+# See .hermes/plans/2026-07-05-fix-ge-data-timescaledb-mismatch.md Phase 2.
+on: {pull_request, workflow_dispatch}
+jobs:
+  check-postgres-pin:
+    runs-on: ubuntu-24.04
+    env:
+      # The timescaledb version ge-data was initdb'd against (pg_extension
+      # extversion on eldo). Bump this ONLY as part of a deliberate ge-data
+      # extension migration, in lockstep with the nixpkgs-postgresql rev.
+      EXPECTED_TIMESCALEDB: "2.27.2"
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            extra-substituters = https://cache.g7c.us
+            extra-trusted-public-keys = cache.g7c.us:dSWpE2B5zK/Fahd7npIQWM4izRnVL+a4LiCAnrjdoFY=
+      - name: verify pinned timescaledb matches ge-data, warn on rolling drift
+        run: |
+          pinned=$(nix eval --raw --impure --expr \
+            '(import (builtins.getFlake (toString ./.)).inputs.nixpkgs-postgresql { system = builtins.currentSystem; }).postgresql16Packages.timescaledb.version')
+          rolling=$(nix eval --raw --impure --expr \
+            '(builtins.getFlake (toString ./.)).inputs.nixpkgs.legacyPackages.${builtins.currentSystem}.postgresql16Packages.timescaledb.version')
+          echo "expected (ge-data)                : $EXPECTED_TIMESCALEDB"
+          echo "pinned   nixpkgs-postgresql       : $pinned"
+          echo "rolling  nixpkgs                  : $rolling"
+
+          if [ "$pinned" != "$EXPECTED_TIMESCALEDB" ]; then
+            echo "::error::PINNED TIMESCALEDB MOVED: nixpkgs-postgresql now ships $pinned, but ge-data is on $EXPECTED_TIMESCALEDB. This would brick every ge-data connection. Revert the nixpkgs-postgresql rev, or migrate ge-data and bump EXPECTED_TIMESCALEDB together."
+            exit 1
+          fi
+
+          if [ "$pinned" != "$rolling" ]; then
+            echo "::warning::timescaledb drift: rolling nixpkgs ships $rolling, pin holds $pinned. Benign — eldo uses the pin. When you eventually want to unpin, migrate ge-data from $pinned to $rolling first."
+          fi
+
+          echo "ok: pinned timescaledb $pinned matches ge-data's expected version"

--- a/SUGGESTIONS.md
+++ b/SUGGESTIONS.md
@@ -49,6 +49,22 @@ Extend the common value instead of replacing it. The `common.nix` → module
 refactor in §4 fixes this for free (you'd append with normal option merging
 instead of `//`).
 
+### 1.4 Postgres+TimescaleDB bundled version drift on eldo
+
+`hosts/eldo/configuration.nix` resolved `pkgs.postgresql_16` through the
+unstable `nixpkgs` input. The bundled `timescaledb.so` inside that derivation
+moves whenever upstream nixpkgs bumps it (2.27.2 → 2.28.0 in 2026-07). Because
+the `ge-data` DB records its extension version in `pg_extension`, any silent
+bump bricks all connections to `ge-data` with
+`ERROR: could not access file "$libdir/timescaledb-<old>": No such file or directory`.
+
+Fixed in `flake.nix` by adding a dedicated `nixpkgs-postgresql` input pinned
+to the postgresql_16 commit that ships timescaledb 2.27.2
+(`567a49d1913ce81ac6e9582e3553dd90a955875f`), and using it exclusively in the
+eldo postgres service. CI check (`.github/workflows/check-postgres-pin.yml`)
+fails if the unstable input ever drifts from the pinned one. Full write-up:
+`.hermes/plans/2026-07-05-fix-ge-data-timescaledb-mismatch.md`.
+
 ---
 
 ## 2. Quick mechanical wins (zero/low risk)

--- a/flake.lock
+++ b/flake.lock
@@ -304,11 +304,11 @@
         "pog": "pog"
       },
       "locked": {
-        "lastModified": 1783128552,
-        "narHash": "sha256-qBCG1z/Y1vw80RZNSb1HlHrXEr+b52CmvYYuDa35kGI=",
+        "lastModified": 1783215876,
+        "narHash": "sha256-HpU6bzwKZ+7kLbTfMvPDaTgEoMIS+LLQVFY+it/S9LE=",
         "owner": "jpetrucciani",
         "repo": "hex",
-        "rev": "54990f411590768b8d386201bbf2ade4644afcff",
+        "rev": "0e7eafcf1d0a39391f80006942a0d26272979710",
         "type": "github"
       },
       "original": {
@@ -387,11 +387,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783099620,
-        "narHash": "sha256-prQSM9PGnrfSaqknJOZ3DCQKbpMiXAWLVC5SHbjLcJ4=",
+        "lastModified": 1783134515,
+        "narHash": "sha256-qMoZazubXlXUD9k/syJ/aiWC4X4g73mwVmZ7Z4+rdpM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b2e4390ff35319c52935d6a700b615da4c0f204d",
+        "rev": "b885baad531fa3d3beae2ba9a0712d22974d8016",
         "type": "github"
       },
       "original": {
@@ -421,11 +421,11 @@
         "vscode-server": "vscode-server"
       },
       "locked": {
-        "lastModified": 1783197636,
-        "narHash": "sha256-tiDWMS9lPsHWoSnmZ7SqEBgGR3qJEuB/qanrOwqcDls=",
+        "lastModified": 1783217667,
+        "narHash": "sha256-l32QubJ4GEDYXpwGJgQ+ozeZfI+7GjzeaIePKuIU+Gs=",
         "owner": "jpetrucciani",
         "repo": "nix",
-        "rev": "0c9f8cabc9090737ca9a2346ddf1903f8c048196",
+        "rev": "385134501b6136155f156a498f777b6a9684420f",
         "type": "github"
       },
       "original": {
@@ -638,13 +638,30 @@
         "type": "github"
       }
     },
+    "nixpkgs-postgresql": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      }
+    },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1782959384,
-        "narHash": "sha256-l57y2CK9dTSChgb6Edg7kkXu5DA4rucVbNFoQHUBjmw=",
-        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "lastModified": 1783224372,
+        "narHash": "sha256-FGQ8TfSm9WviNE/fQAWsKs+y4GkX8fU4EScewpw54Y8=",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1026231.65179426c83b/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1027867.d407951447dc/nixexprs.tar.xz"
       },
       "original": {
         "id": "nixpkgs",
@@ -729,11 +746,11 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1783089885,
-        "narHash": "sha256-gim0irC9CVFaWU+gVu5C9erQtDecF9j3eCEUU6A9ArE=",
-        "rev": "04b4e759e84353279524e23661cd1622f76df6ed",
+        "lastModified": 1783176197,
+        "narHash": "sha256-TD6WnidXbshyohu5EZG+gEeLX8o1vazVdmbD8BI8lE8=",
+        "rev": "c148c8dc4d8befea368b3ce7b5fb5cf71dfba198",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable-small/nixos-26.11pre1027151.04b4e759e843/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable-small/nixos-26.11pre1027634.c148c8dc4d8b/nixexprs.tar.xz"
       },
       "original": {
         "id": "nixpkgs",
@@ -957,6 +974,7 @@
         "nixos-generators": "nixos-generators",
         "nixos-wsl": "nixos-wsl_2",
         "nixpkgs": "nixpkgs_10",
+        "nixpkgs-postgresql": "nixpkgs-postgresql",
         "skribbl": "skribbl",
         "vscode-server": "vscode-server_2"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,14 @@
     # TODO maybe add Keiths / DigDugs things see if they have anything cobi didn't already steal
     jacobi.url = "github:jpetrucciani/nix";
     nixpkgs.url = "nixpkgs/nixos-unstable";
+    # Dedicated input for postgres + timescaledb so the ge-data extension
+    # version (2.27.2 as of 2026-07-05) doesn't move when the unstable
+    # nixpkgs input bumps. Update only via explicit
+    # `nix flake lock --update-input nixpkgs-postgresql`.
+    nixpkgs-postgresql = {
+      url = "github:NixOS/nixpkgs/567a49d1913ce81ac6e9582e3553dd90a955875f";
+      flake = false;
+    };
     nixos-wsl = {
       url = "github:nix-community/NixOS-WSL";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/hosts/eldo/configuration.nix
+++ b/hosts/eldo/configuration.nix
@@ -184,11 +184,25 @@ in
         # rebuild: `cat /var/lib/postgresql/*/PG_VERSION` on eldo. litellm shares
         # this instance, so a major bump (e.g. unstable moving 16 -> 17) would
         # refuse to start on the old data dir.
-        package = pkgs.postgresql_16;
+        # postgres + timescaledb come from a dedicated flake input
+        # (flake.nix#nixpkgs-postgresql) so the ge-data extension version
+        # (2.27.2) doesn't move when the unstable nixpkgs input bumps.
+        # See .hermes/plans/2026-07-05-fix-ge-data-timescaledb-mismatch.md Phase 2.
+        package = (import flake.inputs.nixpkgs-postgresql {
+          inherit (pkgs) system;
+          config = { allowUnfree = true; };
+        }).postgresql_16;
         enableTCPIP = true; # listen on TCP so the k3s ingester pod can reach it
         # TimescaleDB: hypertables + compression for the price history. The lib is
         # preloaded here; the per-database `CREATE EXTENSION` runs when the ge-data
         # schema (init/01_schema.sql) is loaded, not from this config.
+        #
+        # This resolves `ps.timescaledb` against the `package` above (the pinned
+        # nixpkgs-postgresql input), so it stays at 2.27.2 — the version ge-data
+        # was initdb'd against — even as the rolling nixpkgs input bumps. When
+        # 2.27.2 is no longer loadable (e.g. nixpkgs GC's the old bundle), follow
+        # .hermes/plans/2026-07-05-fix-ge-data-timescaledb-mismatch.md to migrate
+        # ge-data to the newer timescaledb and move the nixpkgs-postgresql rev.
         extensions = ps: [ ps.timescaledb ];
         settings.shared_preload_libraries = "timescaledb";
         ensureDatabases = [ "litellm" "ge-data" ];

--- a/modules/home_configurations/packages.nix
+++ b/modules/home_configurations/packages.nix
@@ -96,14 +96,15 @@ in
         # Packages for only Linux
         (
           lib.optionals isLinux [
-            gnutar
-            ntfy-sh
             claude-code
             codex-latest
-            hermes-agent
-            procps
             colmena
             colmena_pog_scripts
+            gnutar
+            hermes-agent
+            ntfy-sh
+            pi-coding-agent
+            procps
           ]
         )
         # Secrets


### PR DESCRIPTION
Fix ge-data TimescaleDB version mismatch on eldo and make it durable.

- Pin postgres+timescaledb to a dedicated nixpkgs-postgresql flake input (rev shipping timescaledb 2.27.2, the version ge-data was initdb'd against) so `nix flake update` can't silently re-break ge-data connections.
- Add a CI check that fails only if the pinned input drifts off 2.27.2, with a non-blocking warning when the rolling nixpkgs input moves.
- Document the incident in SUGGESTIONS.md.
- Add pi and alphabetize home packages.