### PR TITLE
orchestrator module: Heimdall agent-loop timers on eldo (dry-run)

### DIFF
--- a/hosts/eldo/configuration.nix
+++ b/hosts/eldo/configuration.nix
@@ -15,6 +15,7 @@ in
       ./hardware-configuration.nix
       ../../modules/obsidian-autocommit.nix
       ../../modules/monitoring.nix
+      ../../modules/orchestrator.nix
       { inherit (common) services; }
     ];
   # Bootloader.
@@ -131,6 +132,12 @@ in
       monitoring = {
         enable = true;
         secretKeyFile = config.age.secrets.grafana-secret-key.path;
+      };
+
+      # Heimdall agent loop — dryRun stays true until a quiet observation day passes
+      orchestrator = {
+        enable = true;
+        dryRun = true;
       };
 
       ntfy-sh = {

--- a/modules/orchestrator.nix
+++ b/modules/orchestrator.nix
@@ -1,0 +1,77 @@
+# modules/orchestrator.nix
+#
+# Heimdall: the heartbeat agent-loop orchestrator (github.com/fisherrjd/orchestrator).
+# Three oneshot timers run `python -m orc pulse <type>` from the live checkout as
+# jade — headless claude bills the subscription via ~/.claude OAuth, so HOME must
+# be set explicitly (systemd system services don't derive it from User=).
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.orchestrator;
+  claude-code = pkgs.callPackage ../packages/claude-code-latest.nix { };
+  mkPulse = { pulseType, startAt, timeoutSec }: {
+    path = [ pkgs.git pkgs.gh pkgs.curl pkgs.jq pkgs.openssh pkgs.python313 pkgs.nix ];
+    environment = {
+      HOME = "/home/${cfg.user}";
+      ORC_STATE_DIR = cfg.stateDir;
+      ORC_ATLAS_URL = cfg.atlasUrl;
+      ORC_LOKI_URL = cfg.lokiUrl;
+      ORC_NTFY_URL = cfg.ntfyUrl;
+      ORC_NTFY_TOPIC = cfg.ntfyTopic;
+      ORC_CLAUDE_BIN = cfg.claudeBin;
+      ORC_DRY_RUN = if cfg.dryRun then "1" else "0";
+      DISABLE_AUTOUPDATER = "1";
+    };
+    script = ''python -m orc pulse ${pulseType}'';
+    serviceConfig = {
+      User = cfg.user;
+      Type = "oneshot";
+      WorkingDirectory = cfg.repoPath;
+      TimeoutStartSec = timeoutSec;
+    };
+    inherit startAt;
+  };
+
+in
+{
+  options.services.orchestrator = {
+    enable = lib.mkOption { type = lib.types.bool; default = false; };
+    user = lib.mkOption { type = lib.types.str; default = "jade"; };
+    repoPath = lib.mkOption { type = lib.types.str; default = "/home/jade/github/projects/orchestrator"; };
+    stateDir = lib.mkOption { type = lib.types.str; default = "/var/lib/orchestrator"; };
+    # explicit pin: immune to PATH drift between nix-profile and the self-updater
+    claudeBin = lib.mkOption { type = lib.types.str; default = "${claude-code}/bin/claude"; };
+    atlasUrl = lib.mkOption { type = lib.types.str; default = "http://10.0.0.71:3040"; };
+    lokiUrl = lib.mkOption { type = lib.types.str; default = "http://127.0.0.1:3100"; };
+    ntfyUrl = lib.mkOption { type = lib.types.str; default = "http://127.0.0.1:8081"; };
+    ntfyTopic = lib.mkOption { type = lib.types.str; default = "orchestrator"; };
+    # safe-by-default rollout lever: pulses run but file nothing until flipped
+    dryRun = lib.mkOption { type = lib.types.bool; default = true; };
+    logScanInterval = lib.mkOption { type = lib.types.str; default = "*-*-* *:07:00"; };
+    repoHealthInterval = lib.mkOption { type = lib.types.str; default = "*-*-* 03:45:00"; };
+    staffedInterval = lib.mkOption { type = lib.types.str; default = "*:00/15"; };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.tmpfiles.rules = [
+      "d ${cfg.stateDir} 0750 ${cfg.user} users -"
+    ];
+    systemd.services = {
+      orchestrator-log-scan = mkPulse {
+        pulseType = "log-scan";
+        startAt = cfg.logScanInterval;
+        timeoutSec = 600;
+      };
+      orchestrator-repo-health = mkPulse {
+        pulseType = "repo-health";
+        startAt = cfg.repoHealthInterval;
+        timeoutSec = 900;
+      };
+      orchestrator-staffed = mkPulse {
+        pulseType = "staffed";
+        startAt = cfg.staffedInterval;
+        timeoutSec = 3900;
+      };
+    };
+  };
+
+}


### PR DESCRIPTION
## What

New `modules/orchestrator.nix`: three oneshot systemd timers for the Heimdall agent loop ([fisherrjd/orchestrator](https://github.com/fisherrjd/orchestrator)) —

| unit | schedule | timeout |
|---|---|---|
| orchestrator-log-scan | hourly at :07 | 600 s |
| orchestrator-repo-health | daily 03:45 | 900 s |
| orchestrator-staffed | every 15 min | 3900 s |

Each runs `python -m orc pulse <type>` from the live checkout as jade, with `HOME` set explicitly (headless claude needs `~/.claude` OAuth; gh needs `~/.config/gh`) and the claude binary pinned to `packages/claude-code-latest.nix` — immune to PATH drift between the nix-profile install and the self-updater copy.

eldo enables it with **`dryRun = true`**: pulses run on schedule and write pulse_log, but file nothing to atlas and send no pings.

## Verified

- `nixpkgs-fmt --check` + `statix check` clean
- `nix build .#nixosConfigurations.eldo.config.system.build.toplevel` succeeds
- The orc CLI side is already live-tested manually on eldo (tickets filed to atlas)

## After merge

1. `hms` on eldo → `systemctl list-timers 'orchestrator-*'` shows all three
2. After a quiet dry-run day (`orc status`): flip `dryRun = false`, commit, `hms`