### PR TITLE
orchestrator: api write-token plumbing

### DIFF
--- a/hosts/eldo/configuration.nix
+++ b/hosts/eldo/configuration.nix
@@ -56,6 +56,11 @@ in
         owner = "grafana";
         mode = "400";
       };
+      orc-api-token = {
+        file = ../../secrets/orc-api-token.age;
+        owner = "jade";
+        mode = "400";
+      };
     };
   };
   networking = {
@@ -139,6 +144,7 @@ in
       orchestrator = {
         enable = true;
         dryRun = false;
+        apiTokenFile = config.age.secrets.orc-api-token.path;
       };
 
       ntfy-sh = {

--- a/modules/orchestrator.nix
+++ b/modules/orchestrator.nix
@@ -53,9 +53,12 @@ in
     # offset from repo-health so the two nightly model calls never overlap
     secScanInterval = lib.mkOption { type = lib.types.str; default = "*-*-* 04:30:00"; };
     staffedInterval = lib.mkOption { type = lib.types.str; default = "*:00/15"; };
-    # read-only display API for the atlas Heimdall tab; pods reach it via the
+    # display/editor API for the atlas Heimdall tab; pods reach it via the
     # flannel gateway (10.42.0.1), same pattern as postgres
     apiPort = lib.mkOption { type = lib.types.int; default = 3050; };
+    # env file with ORC_API_TOKEN=... enabling the persona write routes;
+    # null keeps the api read-only
+    apiTokenFile = lib.mkOption { type = lib.types.nullOr lib.types.str; default = null; };
   };
 
   config = lib.mkIf cfg.enable {
@@ -95,6 +98,8 @@ in
           User = cfg.user;
           Restart = "on-failure";
           WorkingDirectory = cfg.repoPath;
+        } // lib.optionalAttrs (cfg.apiTokenFile != null) {
+          EnvironmentFile = cfg.apiTokenFile;
         };
         wantedBy = [ "multi-user.target" ];
       };

--- a/secrets/orc-api-token.age
+++ b/secrets/orc-api-token.age
@@ -1,0 +1,9 @@
+age-encryption.org/v1
+-> ssh-ed25519 UIUjPQ M3PX+MonMiAJYHw9I+wgMwaTyOsWicQg8dXijU1jUk4
+DBOKNVMvE3az2y/8ywlMJHTGeV2N+Ph4b9Mlm3DdQbk
+-> ssh-ed25519 PfKrhw jBZBl9uqtpVR0CsPPBnkajpJ5DQn/+KYz6eyxktmxTk
+ASHS/ALffZhQSyoJmfHYXbkNr7bcDqYsNYM65Xs1ST8
+-> ssh-ed25519 scwZuw EAQk+jfwc5tYvlXbe1sZZ04jGU1Op0ORdDtZmOUioio
+6d84bv5m6NzUvA6S2sJNU8CLKtUrBC8HAP0IcK/BXYo
+--- mEFLKjQX15GQHNu8Rvs+hz9GXoNCOv7re2UlgjGWsIA
+Œ›bQ(∫KMè_ücñ9M-HaAIüé’óûä4·

--- a/secrets/secrets.nix
+++ b/secrets/secrets.nix
@@ -11,4 +11,5 @@ in
   "github-runner-token-nix.age".publicKeys = default;
   "ntfy.age".publicKeys = default;
   "grafana-secret-key.age".publicKeys = default;
+  "orc-api-token.age".publicKeys = default;
 }


### PR DESCRIPTION
Companion to orchestrator's authenticated write surface (9e80e87) and atlas#5 (Heimdall persona editor).

- new agenix secret `orc-api-token.age` (default recipients), env-file format `ORC_API_TOKEN=...`
- module option `apiTokenFile` → `EnvironmentFile` on the orchestrator-api unit only; null (default) keeps the API read-only
- eldo: wires the secret in, mode 400 owner jade

After merge + hms, also: `sudo systemctl restart orchestrator-api` (unit env changes should trigger it automatically, but the serve.py code on disk is newer than the running process regardless), and create the matching k8s secret for the atlas pod (command in the ops commit message).